### PR TITLE
fix: support GitHub organizations as project owners

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -1,5 +1,5 @@
 # Project Context Snapshot
-**Last Updated:** 2026-02-16
+**Last Updated:** 2026-03-02
 **Project:** plantas-github-projects-mcp
 
 ## Current State
@@ -7,13 +7,9 @@ Branch: main
 Deployment: development
 
 ## Uncommitted Work
-```
- M .gitattributes
- M .gitignore
-?? .claude/
-?? .plantas.config.json
-```
+**Status:** Clean working tree
 
+**Last Commit:** 9afcd65 - fix: support GitHub organizations in project queries (issue #7) (3 minutes ago)
 ## What's Being Built
 - **Features in progress:** Add create_project_status_update and get_project_status_updates tools
 
@@ -43,6 +39,7 @@ Deployment: development
 3. Deploy to staging
 
 ## Recent Activity
+- **2026-03-02**: 9afcd65 - fix: support GitHub organizations in project queries (issue #7)
 - **2026-02-16**: dd4867b - fix: use REST API for create_milestone
 - **2026-02-07**: 3d03c4a - feat: migrate to Go architecture and port all TS tools
 - **2026-02-07**: 4e9e316 - docs: add migration guide for Go alignment

--- a/src/index.ts
+++ b/src/index.ts
@@ -889,38 +889,78 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const result = await githubGraphQL<any>(
           `
           query($owner: String!, $number: Int!) {
-            user(login: $owner) {
-              projectV2(number: $number) {
-                id
-                title
-                number
-                fields(first: 100) {
-                  nodes {
-                    ... on ProjectV2Field {
-                      id
-                      name
-                      dataType
-                    }
-                    ... on ProjectV2IterationField {
-                      id
-                      name
-                      dataType
-                      configuration {
-                        iterations {
+            repositoryOwner(login: $owner) {
+              ... on User {
+                projectV2(number: $number) {
+                  id
+                  title
+                  number
+                  fields(first: 100) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                        dataType
+                      }
+                      ... on ProjectV2IterationField {
+                        id
+                        name
+                        dataType
+                        configuration {
+                          iterations {
+                            id
+                            title
+                            startDate
+                            duration
+                          }
+                        }
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        dataType
+                        options {
                           id
-                          title
-                          startDate
-                          duration
+                          name
                         }
                       }
                     }
-                    ... on ProjectV2SingleSelectField {
-                      id
-                      name
-                      dataType
-                      options {
+                  }
+                }
+              }
+              ... on Organization {
+                projectV2(number: $number) {
+                  id
+                  title
+                  number
+                  fields(first: 100) {
+                    nodes {
+                      ... on ProjectV2Field {
                         id
                         name
+                        dataType
+                      }
+                      ... on ProjectV2IterationField {
+                        id
+                        name
+                        dataType
+                        configuration {
+                          iterations {
+                            id
+                            title
+                            startDate
+                            duration
+                          }
+                        }
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        dataType
+                        options {
+                          id
+                          name
+                        }
                       }
                     }
                   }
@@ -936,7 +976,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           content: [
             {
               type: "text",
-              text: JSON.stringify(result.user.projectV2, null, 2),
+              text: JSON.stringify(result.repositoryOwner.projectV2, null, 2),
             },
           ],
         };
@@ -1195,14 +1235,14 @@ async function getOwnerId(owner: string): Promise<string> {
   const result = await githubGraphQL<any>(
     `
     query($login: String!) {
-      user(login: $login) {
+      repositoryOwner(login: $login) {
         id
       }
     }
   `,
     { login: owner }
   );
-  return result.user.id;
+  return result.repositoryOwner.id;
 }
 
 async function getRepositoryId(owner: string, repo: string): Promise<string> {

--- a/src/tools/iterations.test.ts
+++ b/src/tools/iterations.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   createIterationField,
   assignIssueToIteration,
+  getProjectId,
   type GraphQLFn,
 } from "./iterations.js";
 
@@ -143,7 +144,7 @@ describe("assignIssueToIteration", () => {
         },
       })
       // getProjectId query
-      .mockResolvedValueOnce({ user: { projectV2: { id: "proj-456" } } })
+      .mockResolvedValueOnce({ repositoryOwner: { projectV2: { id: "proj-456" } } })
       // updateProjectV2ItemFieldValue mutation
       .mockResolvedValueOnce({
         updateProjectV2ItemFieldValue: { projectV2Item: { id: "item-789" } },
@@ -183,7 +184,7 @@ describe("assignIssueToIteration", () => {
           },
         },
       })
-      .mockResolvedValueOnce({ user: { projectV2: { id: "proj-1" } } })
+      .mockResolvedValueOnce({ repositoryOwner: { projectV2: { id: "proj-1" } } })
       .mockResolvedValueOnce({
         updateProjectV2ItemFieldValue: { projectV2Item: { id: "item-1" } },
       }) as unknown as GraphQLFn;
@@ -220,5 +221,51 @@ describe("assignIssueToIteration", () => {
         iterationId: "i-1",
       })
     ).rejects.toThrow("Issue #42 not found in project #5");
+  });
+});
+
+describe("getProjectId (org support)", () => {
+  it("uses repositoryOwner instead of user in the query", async () => {
+    const gql = vi.fn().mockResolvedValueOnce({
+      repositoryOwner: { projectV2: { id: "proj-org-1" } },
+    }) as unknown as GraphQLFn;
+
+    await getProjectId(gql, "netliferesearch", 3);
+
+    const { query } = captureCall(vi.mocked(gql), 0);
+    expect(query).toContain("repositoryOwner(login: $owner)");
+    expect(query).not.toContain("user(login: $owner)");
+  });
+
+  it("includes inline fragments for both User and Organization", async () => {
+    const gql = vi.fn().mockResolvedValueOnce({
+      repositoryOwner: { projectV2: { id: "proj-org-2" } },
+    }) as unknown as GraphQLFn;
+
+    await getProjectId(gql, "netliferesearch", 3);
+
+    const { query } = captureCall(vi.mocked(gql), 0);
+    expect(query).toContain("... on User");
+    expect(query).toContain("... on Organization");
+  });
+
+  it("resolves project ID for an org owner", async () => {
+    const gql = vi.fn().mockResolvedValueOnce({
+      repositoryOwner: { projectV2: { id: "proj-org-abc" } },
+    }) as unknown as GraphQLFn;
+
+    const id = await getProjectId(gql, "netliferesearch", 3);
+
+    expect(id).toBe("proj-org-abc");
+  });
+
+  it("resolves project ID for a user owner", async () => {
+    const gql = vi.fn().mockResolvedValueOnce({
+      repositoryOwner: { projectV2: { id: "proj-user-xyz" } },
+    }) as unknown as GraphQLFn;
+
+    const id = await getProjectId(gql, "octocat", 7);
+
+    expect(id).toBe("proj-user-xyz");
   });
 });

--- a/src/tools/iterations.ts
+++ b/src/tools/iterations.ts
@@ -31,16 +31,23 @@ export async function getProjectId(
   const result = await graphqlFn<any>(
     `
     query($owner: String!, $number: Int!) {
-      user(login: $owner) {
-        projectV2(number: $number) {
-          id
+      repositoryOwner(login: $owner) {
+        ... on User {
+          projectV2(number: $number) {
+            id
+          }
+        }
+        ... on Organization {
+          projectV2(number: $number) {
+            id
+          }
         }
       }
     }
   `,
     { owner, number }
   );
-  return result.user.projectV2.id;
+  return result.repositoryOwner.projectV2.id;
 }
 
 export async function getProjectItemId(


### PR DESCRIPTION
## Summary

Fixes #7 — tools that used `user(login:)` in GraphQL queries failed with `Could not resolve to a User` when the owner was a GitHub organization.

- Replace `user(login:)` with `repositoryOwner(login:)` in `getOwnerId` (`index.ts`) and `getProjectId` (`iterations.ts`) — `repositoryOwner` resolves both users and orgs
- Use `... on User` / `... on Organization` inline fragments for `projectV2` lookups since that field isn't on the `RepositoryOwner` interface directly
- Apply the same fix to the `get_project_info` inline query in `index.ts`
- Update existing `getProjectId` mocks in the test suite to match the new response shape
- Add 4 new tests in `getProjectId (org support)` suite verifying query structure and correct ID resolution for both users and orgs

## Test plan

- [x] All 11 tests pass (`npm test`)
- [x] Call `get_project_info` with an org-owned project (e.g. `{ owner: "netliferesearch", projectNumber: 3 }`) — should return project fields without error
- [x] Call `create_project` with an org owner — should resolve owner ID and create the project
- [x] Call `assign_issue_to_iteration` with an org owner — should resolve project ID and assign correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)