### PR TITLE
fix(iterations): correct GraphQL schema misuse and preserve item assignments

### DIFF
--- a/src/tools/iterations.test.ts
+++ b/src/tools/iterations.test.ts
@@ -45,7 +45,11 @@ describe("createIterationField", () => {
     expect(variables).not.toHaveProperty("projectId");
   });
 
-  it("step 2 mutation uses ProjectV2IterationFieldConfigurationIterationInput", async () => {
+  // Regression: the mutation previously declared
+  // `[ProjectV2IterationFieldConfigurationIterationInput!]!`, a type that does not exist in
+  // GitHub's schema. The real type, per docs.github.com/public/fpt/schema.docs.graphql, is
+  // `[ProjectV2Iteration!]!`.
+  it("step 2 mutation declares the real ProjectV2Iteration input type", async () => {
     const gql = vi.fn()
       .mockResolvedValueOnce({
         createProjectV2Field: { projectV2Field: { id: "field-abc" } },
@@ -70,8 +74,8 @@ describe("createIterationField", () => {
 
     const { query } = captureCall(vi.mocked(gql), 1);
 
-    expect(query).toContain("ProjectV2IterationFieldConfigurationIterationInput");
-    expect(query).not.toContain("ProjectV2IterationFieldIterationInput");
+    expect(query).toContain("[ProjectV2Iteration!]!");
+    expect(query).not.toContain("ProjectV2IterationFieldConfigurationIterationInput");
   });
 
   it("step 2 mutation passes fieldId, duration, startDate, and iterations", async () => {
@@ -272,33 +276,76 @@ describe("getProjectId (org support)", () => {
   });
 });
 
-// Helper to create a mock that returns field config then mutation result
+type Iter = { id: string; title: string; startDate: string; duration: number };
+
+/**
+ * Mock the three-call sequence every field update now performs:
+ *   1. getIterationFieldConfig query
+ *   2. snapshotIterationAssignments query
+ *   3. updateProjectV2Field mutation
+ * followed by one restore mutation per snapshotted assignment.
+ *
+ * The config shape mirrors GitHub's real schema: `ProjectV2IterationFieldConfiguration`
+ * exposes `duration`, `startDay`, `iterations`, `completedIterations` — and notably
+ * NO `startDate`. Querying `startDate` there is what made these tools fail in production.
+ */
 function mockWithFieldConfig(
-  existingIterations: Array<{ id: string; title: string; startDate: string; duration: number }>,
+  existingIterations: Iter[],
   mutationResult: any,
+  opts: {
+    completedIterations?: Iter[];
+    assignments?: Array<{ itemId: string; number: number; title: string }>;
+  } = {},
 ) {
-  return vi.fn()
-    // getIterationFieldConfig query
+  const assignments = opts.assignments ?? [];
+  const mock = vi.fn()
+    // 1. getIterationFieldConfig
     .mockResolvedValueOnce({
       node: {
         fields: {
           nodes: [
             {
               id: "field-abc",
+              name: "Sprint",
               configuration: {
                 duration: 7,
-                startDate: "2026-01-01",
+                startDay: 1,
                 iterations: existingIterations,
-                completedIterations: [],
+                completedIterations: opts.completedIterations ?? [],
               },
             },
           ],
         },
       },
     })
-    // updateProjectV2Field mutation
-    .mockResolvedValueOnce(mutationResult) as unknown as GraphQLFn;
+    // 2. snapshotIterationAssignments
+    .mockResolvedValueOnce({
+      node: {
+        items: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: assignments.map((a) => ({
+            id: a.itemId,
+            content: { __typename: "Issue", number: a.number },
+            fieldValueByName: { title: a.title },
+          })),
+        },
+      },
+    })
+    // 3. updateProjectV2Field
+    .mockResolvedValueOnce(mutationResult);
+
+  // 4..n restore mutations
+  for (const _ of assignments) {
+    mock.mockResolvedValueOnce({
+      updateProjectV2ItemFieldValue: { projectV2Item: { id: "item" } },
+    });
+  }
+
+  return mock as unknown as GraphQLFn;
 }
+
+/** Index of the updateProjectV2Field call within the mocked sequence. */
+const MUTATION_CALL = 2;
 
 describe("addIteration", () => {
   it("fetches existing iterations and appends the new one", async () => {
@@ -328,7 +375,7 @@ describe("addIteration", () => {
       duration: 7,
     });
 
-    const { variables } = captureCall(vi.mocked(gql), 1);
+    const { variables } = captureCall(vi.mocked(gql), MUTATION_CALL);
     expect((variables.iterations as any[])).toHaveLength(2);
     expect((variables.iterations as any[])[0]).toEqual({
       title: "Sprint 1",
@@ -342,13 +389,16 @@ describe("addIteration", () => {
     });
   });
 
-  it("preserves field-level duration and startDate from config", async () => {
+  // Regression: the config query used to request `configuration { startDate }`, which does
+  // not exist on ProjectV2IterationFieldConfiguration and made every call fail with
+  // "Field 'startDate' doesn't exist on type 'ProjectV2IterationFieldConfiguration'".
+  it("queries startDay, never startDate, on the field configuration", async () => {
     const gql = mockWithFieldConfig([], {
       updateProjectV2Field: {
         projectV2Field: {
           id: "field-abc",
           name: "Sprint",
-          configuration: { iterations: [] },
+          configuration: { iterations: [], completedIterations: [] },
         },
       },
     });
@@ -361,9 +411,160 @@ describe("addIteration", () => {
       duration: 14,
     });
 
-    const { variables } = captureCall(vi.mocked(gql), 1);
+    const { query } = captureCall(vi.mocked(gql), 0);
+    // Inspect only the direct children of `configuration`, i.e. everything before the
+    // nested `iterations { ... }` selection (where startDate is legitimate).
+    const configBlock = query.slice(
+      query.indexOf("configuration {"),
+      query.indexOf("iterations {"),
+    );
+    expect(configBlock).toContain("startDay");
+    expect(configBlock).not.toContain("startDate");
+  });
+
+  // Regression: mocks accept any query string, so an undeclared GraphQL variable sails
+  // through unit tests and only fails against the real API. Assert every $var used in a
+  // query is also declared in its signature.
+  it("declares every GraphQL variable it references", async () => {
+    const gql = mockWithFieldConfig([], {
+      updateProjectV2Field: {
+        projectV2Field: {
+          id: "field-abc",
+          name: "Sprint",
+          configuration: { iterations: [], completedIterations: [] },
+        },
+      },
+    });
+
+    await addIteration(gql, {
+      projectId: "proj-xyz",
+      fieldId: "field-abc",
+      title: "Sprint 1",
+      startDate: "2026-03-01",
+      duration: 7,
+    });
+
+    for (const call of vi.mocked(gql).mock.calls) {
+      const query = call[0] as string;
+      const signature = query.slice(0, query.indexOf("{"));
+      const declared = new Set(
+        [...signature.matchAll(/\$(\w+)\s*:/g)].map((m) => m[1]),
+      );
+      const used = new Set([...query.matchAll(/\$(\w+)/g)].map((m) => m[1]));
+      for (const name of used) {
+        expect(
+          declared.has(name),
+          `$${name} is used but not declared in: ${signature.trim()}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("carries completed iterations through so history is not dropped", async () => {
+    const completed = [
+      { id: "old-1", title: "Sprint 0", startDate: "2025-12-25", duration: 7 },
+    ];
+    const active = [
+      { id: "iter-1", title: "Sprint 1", startDate: "2026-01-01", duration: 7 },
+    ];
+    const gql = mockWithFieldConfig(active, {
+      updateProjectV2Field: {
+        projectV2Field: {
+          id: "field-abc",
+          name: "Sprint",
+          configuration: { iterations: active, completedIterations: completed },
+        },
+      },
+    }, { completedIterations: completed });
+
+    await addIteration(gql, {
+      projectId: "proj-xyz",
+      fieldId: "field-abc",
+      title: "Sprint 2",
+      startDate: "2026-01-08",
+      duration: 7,
+    });
+
+    const { variables } = captureCall(vi.mocked(gql), MUTATION_CALL);
+    const titles = (variables.iterations as any[]).map((i) => i.title);
+    // Chronological: completed first, then active, then the new one.
+    expect(titles).toEqual(["Sprint 0", "Sprint 1", "Sprint 2"]);
+    // startDate is "the start date for the first iteration".
+    expect(variables.startDate).toBe("2025-12-25");
     expect(variables.duration).toBe(7);
-    expect(variables.startDate).toBe("2026-01-01");
+  });
+
+  // Regression: updateProjectV2Field regenerates every iteration ID, detaching all item
+  // values. Without a snapshot/restore pass, adding a sprint silently wipes the board.
+  it("snapshots assignments and restores them against the new iteration ids", async () => {
+    const active = [
+      { id: "iter-1", title: "Sprint 1", startDate: "2026-01-01", duration: 7 },
+    ];
+    const gql = mockWithFieldConfig(active, {
+      updateProjectV2Field: {
+        projectV2Field: {
+          id: "field-abc",
+          name: "Sprint",
+          configuration: {
+            // Note the regenerated id — this is what GitHub actually does.
+            iterations: [
+              { id: "REGENERATED", title: "Sprint 1", startDate: "2026-01-01", duration: 7 },
+              { id: "iter-new", title: "Sprint 2", startDate: "2026-01-08", duration: 7 },
+            ],
+            completedIterations: [],
+          },
+        },
+      },
+    }, { assignments: [{ itemId: "item-1", number: 42, title: "Sprint 1" }] });
+
+    const result: any = await addIteration(gql, {
+      projectId: "proj-xyz",
+      fieldId: "field-abc",
+      title: "Sprint 2",
+      startDate: "2026-01-08",
+      duration: 7,
+    });
+
+    expect(result.assignmentsRestored).toEqual({ restored: 1, failed: [] });
+
+    // The restore mutation runs after the field update and targets the NEW id.
+    const { query, variables } = captureCall(vi.mocked(gql), MUTATION_CALL + 1);
+    expect(query).toContain("updateProjectV2ItemFieldValue");
+    expect(variables.itemId).toBe("item-1");
+    expect(variables.iterationId).toBe("REGENERATED");
+  });
+
+  it("reports assignments it could not restore instead of failing silently", async () => {
+    const active = [
+      { id: "iter-1", title: "Sprint 1", startDate: "2026-01-01", duration: 7 },
+    ];
+    const gql = mockWithFieldConfig(active, {
+      updateProjectV2Field: {
+        projectV2Field: {
+          id: "field-abc",
+          name: "Sprint",
+          // "Sprint 1" is gone, so its assignment cannot be remapped.
+          configuration: {
+            iterations: [
+              { id: "iter-new", title: "Sprint 2", startDate: "2026-01-08", duration: 7 },
+            ],
+            completedIterations: [],
+          },
+        },
+      },
+    }, { assignments: [{ itemId: "item-1", number: 42, title: "Sprint 1" }] });
+
+    const result: any = await addIteration(gql, {
+      projectId: "proj-xyz",
+      fieldId: "field-abc",
+      title: "Sprint 2",
+      startDate: "2026-01-08",
+      duration: 7,
+    });
+
+    expect(result.assignmentsRestored.restored).toBe(0);
+    expect(result.assignmentsRestored.failed).toHaveLength(1);
+    expect(result.assignmentsRestored.failed[0].label).toBe("Issue #42");
   });
 
   it("throws when field is not found", async () => {
@@ -373,9 +574,10 @@ describe("addIteration", () => {
           nodes: [
             {
               id: "other-field",
+              name: "Sprint",
               configuration: {
                 duration: 7,
-                startDate: "2026-01-01",
+                startDay: 1,
                 iterations: [],
                 completedIterations: [],
               },
@@ -421,22 +623,82 @@ describe("updateIteration", () => {
       duration: 14,
     });
 
-    const { variables } = captureCall(vi.mocked(gql), 1);
+    const { variables } = captureCall(vi.mocked(gql), MUTATION_CALL);
     expect((variables.iterations as any[])).toHaveLength(2);
     // First iteration unchanged
     expect((variables.iterations as any[])[0]).toEqual({
-      id: "iter-1",
       title: "Sprint 1",
       startDate: "2026-01-01",
       duration: 7,
     });
     // Second iteration updated
     expect((variables.iterations as any[])[1]).toEqual({
-      id: "iter-2",
       title: "Sprint 2 (extended)",
       startDate: "2026-01-08",
       duration: 14,
     });
+  });
+
+  // Regression: `ProjectV2Iteration` has no `id` field, so including one is a query error.
+  it("never sends an id inside the iterations payload", async () => {
+    const existing = [
+      { id: "iter-1", title: "Sprint 1", startDate: "2026-01-01", duration: 7 },
+      { id: "iter-2", title: "Sprint 2", startDate: "2026-01-08", duration: 7 },
+    ];
+    const gql = mockWithFieldConfig(existing, {
+      updateProjectV2Field: {
+        projectV2Field: {
+          id: "field-abc",
+          name: "Sprint",
+          configuration: { iterations: existing, completedIterations: [] },
+        },
+      },
+    });
+
+    await updateIteration(gql, {
+      projectId: "proj-xyz",
+      fieldId: "field-abc",
+      iterationId: "iter-2",
+      duration: 14,
+    });
+
+    const { variables } = captureCall(vi.mocked(gql), MUTATION_CALL);
+    for (const iteration of variables.iterations as any[]) {
+      expect(iteration).not.toHaveProperty("id");
+      expect(Object.keys(iteration).sort()).toEqual(["duration", "startDate", "title"]);
+    }
+  });
+
+  it("remaps assignments when the target iteration is renamed", async () => {
+    const existing = [
+      { id: "iter-1", title: "Sprint 1", startDate: "2026-01-01", duration: 7 },
+    ];
+    const gql = mockWithFieldConfig(existing, {
+      updateProjectV2Field: {
+        projectV2Field: {
+          id: "field-abc",
+          name: "Sprint",
+          configuration: {
+            iterations: [
+              { id: "NEW-ID", title: "Renamed", startDate: "2026-01-01", duration: 7 },
+            ],
+            completedIterations: [],
+          },
+        },
+      },
+    }, { assignments: [{ itemId: "item-1", number: 7, title: "Sprint 1" }] });
+
+    const result: any = await updateIteration(gql, {
+      projectId: "proj-xyz",
+      fieldId: "field-abc",
+      iterationId: "iter-1",
+      title: "Renamed",
+    });
+
+    // Snapshot said "Sprint 1"; the iteration is now "Renamed". Restore must follow it.
+    expect(result.assignmentsRestored).toEqual({ restored: 1, failed: [] });
+    const { variables } = captureCall(vi.mocked(gql), MUTATION_CALL + 1);
+    expect(variables.iterationId).toBe("NEW-ID");
   });
 
   it("throws when iteration is not found", async () => {
@@ -464,7 +726,7 @@ describe("updateIteration", () => {
         projectV2Field: {
           id: "field-abc",
           name: "Sprint",
-          configuration: { iterations: existing },
+          configuration: { iterations: existing, completedIterations: [] },
         },
       },
     });
@@ -477,9 +739,8 @@ describe("updateIteration", () => {
       // startDate and duration omitted
     });
 
-    const { variables } = captureCall(vi.mocked(gql), 1);
+    const { variables } = captureCall(vi.mocked(gql), MUTATION_CALL);
     expect((variables.iterations as any[])[0]).toEqual({
-      id: "iter-1",
       title: "Sprint 1 renamed",
       startDate: "2026-01-01",
       duration: 7,

--- a/src/tools/iterations.ts
+++ b/src/tools/iterations.ts
@@ -123,7 +123,7 @@ export async function createIterationField(
   // Step 2: Update the field with iteration configuration
   const updateResult = await graphqlFn<any>(
     `
-    mutation($fieldId: ID!, $duration: Int!, $startDate: Date!, $iterations: [ProjectV2IterationFieldConfigurationIterationInput!]!) {
+    mutation($fieldId: ID!, $duration: Int!, $startDate: Date!, $iterations: ${ITERATIONS_ARG_TYPE}) {
       updateProjectV2Field(input: {
         fieldId: $fieldId
         iterationConfiguration: {
@@ -184,26 +184,52 @@ interface IterationConfig {
   duration: number;
 }
 
+/**
+ * GraphQL type of the `iterations` argument on ProjectV2IterationFieldConfigurationInput.
+ *
+ * Per GitHub's published schema (docs.github.com/public/fpt/schema.docs.graphql):
+ *   input ProjectV2IterationFieldConfigurationInput {
+ *     duration: Int!
+ *     iterations: [ProjectV2Iteration!]!
+ *     startDate: Date!
+ *   }
+ *
+ * Note `ProjectV2Iteration` has exactly three fields — duration, startDate, title —
+ * and NO `id`. Sending an `id` is a query error.
+ */
+const ITERATIONS_ARG_TYPE = "[ProjectV2Iteration!]!";
+
+/** A single item's iteration assignment, captured before a destructive field update. */
+export interface IterationAssignment {
+  itemId: string;
+  /** Human-readable label for diagnostics only. */
+  label: string;
+  iterationTitle: string;
+}
+
 async function getIterationFieldConfig(
   graphqlFn: GraphQLFn,
   projectId: string,
   fieldId: string,
-): Promise<{ duration: number; startDate: string; iterations: IterationConfig[] }> {
+): Promise<{
+  name: string;
+  duration: number;
+  startDate: string;
+  iterations: IterationConfig[];
+}> {
   const result = await graphqlFn<any>(
     `
     query($projectId: ID!) {
       node(id: $projectId) {
         ... on ProjectV2 {
-          field(name: "") {
-            __typename
-          }
           fields(first: 100) {
             nodes {
               ... on ProjectV2IterationField {
                 id
+                name
                 configuration {
                   duration
-                  startDate
+                  startDay
                   iterations {
                     id
                     title
@@ -234,14 +260,123 @@ async function getIterationFieldConfig(
     throw new Error(`Iteration field ${fieldId} not found in project`);
   }
 
+  // `completedIterations` comes back newest-first; the mutation expects chronological
+  // order, and completed iterations precede active ones.
+  const completed = [...field.configuration.completedIterations].reverse();
+  const iterations = [...completed, ...field.configuration.iterations];
+
   return {
+    name: field.name,
     duration: field.configuration.duration,
-    startDate: field.configuration.startDate,
-    iterations: [
-      ...field.configuration.iterations,
-      ...field.configuration.completedIterations,
-    ],
+    // The input requires `startDate` ("the start date for the first iteration"), but the
+    // output type exposes `startDay` (a day-of-week integer) and no equivalent date. Derive
+    // it from the earliest iteration instead.
+    startDate: iterations[0]?.startDate ?? "",
+    iterations,
   };
+}
+
+/**
+ * Capture every item's iteration assignment before a field update.
+ *
+ * Required because `updateProjectV2Field` regenerates the ID of every iteration — even
+ * ones resubmitted byte-identically — which detaches all item values. Assignments are
+ * keyed by iteration *title*, the only stable identifier across the mutation.
+ */
+export async function snapshotIterationAssignments(
+  graphqlFn: GraphQLFn,
+  projectId: string,
+  fieldName: string,
+): Promise<IterationAssignment[]> {
+  const out: IterationAssignment[] = [];
+  let cursor: string | null = null;
+
+  for (;;) {
+    const result: any = await graphqlFn<any>(
+      `
+      query($projectId: ID!, $cursor: String, $fieldName: String!) {
+        node(id: $projectId) {
+          ... on ProjectV2 {
+            items(first: 100, after: $cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                content {
+                  __typename
+                  ... on Issue { number }
+                  ... on PullRequest { number }
+                  ... on DraftIssue { title }
+                }
+                fieldValueByName(name: $fieldName) {
+                  ... on ProjectV2ItemFieldIterationValue { title }
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+      { projectId, cursor, fieldName },
+    );
+
+    const page = result.node.items;
+    for (const node of page.nodes) {
+      if (!node.fieldValueByName?.title) continue;
+      const content = node.content ?? {};
+      out.push({
+        itemId: node.id,
+        label:
+          content.number != null
+            ? `${content.__typename} #${content.number}`
+            : (content.title ?? node.id),
+        iterationTitle: node.fieldValueByName.title,
+      });
+    }
+
+    if (!page.pageInfo.hasNextPage) return out;
+    cursor = page.pageInfo.endCursor;
+  }
+}
+
+/** Re-apply a snapshot after the field update, mapping old titles to freshly-minted IDs. */
+export async function restoreIterationAssignments(
+  graphqlFn: GraphQLFn,
+  projectId: string,
+  fieldId: string,
+  snapshot: IterationAssignment[],
+  freshIterations: Array<{ id: string; title: string }>,
+): Promise<{ restored: number; failed: IterationAssignment[] }> {
+  const idByTitle = new Map(freshIterations.map((i) => [i.title, i.id]));
+  const failed: IterationAssignment[] = [];
+  let restored = 0;
+
+  for (const entry of snapshot) {
+    const iterationId = idByTitle.get(entry.iterationTitle);
+    if (!iterationId) {
+      failed.push(entry);
+      continue;
+    }
+    try {
+      await graphqlFn<any>(
+        `
+        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $projectId
+            itemId: $itemId
+            fieldId: $fieldId
+            value: { iterationId: $iterationId }
+          }) { projectV2Item { id } }
+        }
+      `,
+        { projectId, itemId: entry.itemId, fieldId, iterationId },
+      );
+      restored++;
+    } catch {
+      failed.push(entry);
+    }
+  }
+
+  return { restored, failed };
 }
 
 export async function addIteration(
@@ -268,9 +403,16 @@ export async function addIteration(
     },
   ];
 
+  // Capture assignments first — the mutation below detaches every one of them.
+  const snapshot = await snapshotIterationAssignments(
+    graphqlFn,
+    input.projectId,
+    config.name,
+  );
+
   const result = await graphqlFn<any>(
     `
-    mutation($fieldId: ID!, $duration: Int!, $startDate: Date!, $iterations: [ProjectV2IterationFieldConfigurationIterationInput!]!) {
+    mutation($fieldId: ID!, $duration: Int!, $startDate: Date!, $iterations: ${ITERATIONS_ARG_TYPE}) {
       updateProjectV2Field(input: {
         fieldId: $fieldId
         iterationConfiguration: {
@@ -290,6 +432,12 @@ export async function addIteration(
                 startDate
                 duration
               }
+              completedIterations {
+                id
+                title
+                startDate
+                duration
+              }
             }
           }
         }
@@ -299,12 +447,24 @@ export async function addIteration(
     {
       fieldId: input.fieldId,
       duration: config.duration,
-      startDate: config.startDate,
+      startDate: config.startDate || input.startDate,
       iterations: allIterations,
     },
   );
 
-  return result.updateProjectV2Field.projectV2Field;
+  const field = result.updateProjectV2Field.projectV2Field;
+  const restoreReport = await restoreIterationAssignments(
+    graphqlFn,
+    input.projectId,
+    input.fieldId,
+    snapshot,
+    [
+      ...(field.configuration.completedIterations ?? []),
+      ...(field.configuration.iterations ?? []),
+    ],
+  );
+
+  return { ...field, assignmentsRestored: restoreReport };
 }
 
 export async function updateIteration(
@@ -323,26 +483,41 @@ export async function updateIteration(
     throw new Error(`Iteration ${input.iterationId} not found in field`);
   }
 
+  // `ProjectV2Iteration` accepts only title/startDate/duration — never `id`.
   const allIterations = config.iterations.map((it) => {
     if (it.id === input.iterationId) {
       return {
-        id: it.id,
         title: input.title ?? it.title,
         startDate: input.startDate ?? it.startDate,
         duration: input.duration ?? it.duration,
       };
     }
     return {
-      id: it.id,
       title: it.title,
       startDate: it.startDate,
       duration: it.duration,
     };
   });
 
+  // Renaming an iteration breaks title-based restore, so remap the snapshot entries
+  // that pointed at the old title before restoring.
+  const snapshot = await snapshotIterationAssignments(
+    graphqlFn,
+    input.projectId,
+    config.name,
+  );
+  const renamedTo = input.title && input.title !== target.title ? input.title : null;
+  const adjustedSnapshot = renamedTo
+    ? snapshot.map((entry) =>
+        entry.iterationTitle === target.title
+          ? { ...entry, iterationTitle: renamedTo }
+          : entry,
+      )
+    : snapshot;
+
   const result = await graphqlFn<any>(
     `
-    mutation($fieldId: ID!, $duration: Int!, $startDate: Date!, $iterations: [ProjectV2IterationFieldConfigurationIterationInput!]!) {
+    mutation($fieldId: ID!, $duration: Int!, $startDate: Date!, $iterations: ${ITERATIONS_ARG_TYPE}) {
       updateProjectV2Field(input: {
         fieldId: $fieldId
         iterationConfiguration: {
@@ -362,6 +537,12 @@ export async function updateIteration(
                 startDate
                 duration
               }
+              completedIterations {
+                id
+                title
+                startDate
+                duration
+              }
             }
           }
         }
@@ -376,7 +557,19 @@ export async function updateIteration(
     },
   );
 
-  return result.updateProjectV2Field.projectV2Field;
+  const field = result.updateProjectV2Field.projectV2Field;
+  const restoreReport = await restoreIterationAssignments(
+    graphqlFn,
+    input.projectId,
+    input.fieldId,
+    adjustedSnapshot,
+    [
+      ...(field.configuration.completedIterations ?? []),
+      ...(field.configuration.iterations ?? []),
+    ],
+  );
+
+  return { ...field, assignmentsRestored: restoreReport };
 }
 
 export async function assignIssueToIteration(


### PR DESCRIPTION
## Summary

`add_iteration` and `update_iteration` were unusable — every call failed with a GraphQL error — and would have been **destructive** once callable. This fixes four defects and adds the safety pass the tools were missing.

Found while adding a sprint to a real project board, which detached the Sprint value on all 109 items.

## The defects

| # | Defect | Effect |
|---|---|---|
| 1 | Config query requested `configuration { startDate }` | Every call failed: *"Field 'startDate' doesn't exist on type `ProjectV2IterationFieldConfiguration`"*. The real fields are `duration`, `startDay`, `iterations`, `completedIterations` |
| 2 | Mutations declared `[ProjectV2IterationFieldConfigurationIterationInput!]!` | That type does not exist. The real one is `[ProjectV2Iteration!]!` |
| 3 | `updateIteration` sent `id` inside each iteration object | `ProjectV2Iteration` has exactly three fields — `duration`, `startDate`, `title` — and no `id` |
| 4 | Neither tool preserved item assignments | **Adding one sprint silently wiped the board's entire sprint history** |

Defects 1–3 make the tools fail. Defect 4 is the dangerous one.

## Why defect 4 is unavoidable without a snapshot

`updateProjectV2Field` regenerates the ID of **every** iteration — including ones resubmitted byte-identically. Since each item's Sprint value stores an `iterationId`, they all detach. Verified three ways:

- **Published schema** — `ProjectV2Iteration` (input) has no `id`, while `ProjectV2IterationFieldIteration` (output) does. You can read an ID but never send one back, so the server cannot know which iteration you meant.
- **Empirically** — re-sending an identical config regenerated every ID (`f582f3cc`→`acb720ac`) and items read back `null`.
- **No alternative exists** — of 32 `ProjectV2*` mutations, none has "Iteration" in its name; `iterationConfiguration` appears only in `CreateProjectV2FieldInput` and `UpdateProjectV2FieldInput`; Projects v2 has no REST surface; `gh project field-create` doesn't support ITERATION.

This is a known, unresolved GitHub limitation — see [community#157957](https://github.com/orgs/community/discussions/157957) (open since Apr 2025, no staff response) and [community#198803](https://github.com/orgs/community/discussions/198803). The same flaw affects single-select options.

## The fix

`addIteration` and `updateIteration` now **snapshot → mutate → restore**: capture every item's assignment, apply the mutation, then re-assign against the freshly-minted IDs keyed by iteration *title* (the only identifier stable across the call). They return `{ restored, failed }` instead of failing silently.

- Renames are remapped, so a retitled iteration keeps its items.
- Completed iterations are passed through in chronological order, so history isn't dropped.

## On the tests

The existing tests passed against broken code because they mocked a **fabricated schema** — one was even named `"step 2 mutation uses ProjectV2IterationFieldConfigurationIterationInput"`, asserting the nonexistent type. Rewritten against the real shape, with regression coverage per defect.

Verified by reintroducing all four bugs and confirming the suite fails.

Also added a test asserting every `$variable` used in a query is declared in its signature. Mocks accept any string, so an undeclared variable passes unit tests and only fails against the real API — which is exactly what happened while writing this fix.

## Verification

- 38 tests → **44**, all passing; `tsc --noEmit` clean
- End-to-end against a live scratch project: two assignments **survived** an `add_iteration` call whose iteration IDs all changed (`cc641931`→`ff79ed39`, `dcdcc459`→`c2855f36`), confirmed by independent re-query
- Scratch projects deleted afterwards

## Note

`README.md` and `INSTALL.md` list these tools without documenting the destructive-update caveat. Happy to add that here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
